### PR TITLE
Minor updates

### DIFF
--- a/src/public/views/footer.jsx
+++ b/src/public/views/footer.jsx
@@ -54,7 +54,7 @@ export default React.createClass({
                                     <Link to='/resources'>Resources</Link>
                                 </li>
                                 <li>
-                                    <Link to='/conference'>Conferences</Link>
+                                    <Link to='/conferences'>Conferences</Link>
                                 </li>
                             </ul>
                         </div>

--- a/src/public/views/header.jsx
+++ b/src/public/views/header.jsx
@@ -41,7 +41,7 @@ export default React.createClass({
                             <Link to='/resources'>Resources</Link>
                         </li>
                         <li className={this.getClassName('conference')}>
-                            <Link to='/conference'>Conferences</Link>
+                            <Link to='/conferences'>Conferences</Link>
                         </li>
                     </ul>
                 </nav>

--- a/src/public/views/main.jsx
+++ b/src/public/views/main.jsx
@@ -13,7 +13,7 @@ import Members from './pages/members.jsx';
 import Resources from './pages/resources.jsx';
 import Articles from './pages/articles.jsx';
 import NotFound from './pages/not-found.jsx';
-import Conference from './pages/conference.jsx';
+import Conferences from './pages/conferences.jsx';
 
 ReactDOM.render((
     <Router history={createHistory()}>
@@ -26,7 +26,7 @@ ReactDOM.render((
             <Route path='members' component={Members} />
             <Route path='resources' component={Resources} />
             <Route path='articles' component={Articles} />
-            <Route path='conference' component={Conference} />
+            <Route path='conferences' component={Conferences} />
             <Route path='*' component={NotFound} />
         </Route>
     </Router>

--- a/src/public/views/pages/conferences.jsx
+++ b/src/public/views/pages/conferences.jsx
@@ -16,33 +16,33 @@ export default React.createClass({
                 <Title title="Satoshi's Vision" />
                 <div className='section'>
                     <div className='container'>
-                        <h1 id="5eed" class="graf--h3 graf--leading graf--title">Satoshi’s Vision: Bitcoin Development &amp; Scaling Conference</h1>
-                        <p id="7afc" class="graf--p graf-after--h3"><em class="markup--em markup--p-em">Sunday, September 25, 2016 | Westin St. Francis, San Francisco</em></p>
-                        <p id="1807" class="graf--p graf-after--p">It is with great excitement that we announce “Satoshi’s Vision: Bitcoin Development &amp; Scaling Conference.” This single-day event will bring together like-minded developers, researchers and industry leaders committed to the vision of Bitcoin as a peer-to-peer electronic cash system for the world’s seven billion people.</p>
+                        <h1 id="5eed" className="graf--h3 graf--leading graf--title">Satoshi’s Vision: Bitcoin Development &amp; Scaling Conference</h1>
+                        <p id="7afc" className="graf--p graf-after--h3"><em className="markup--em markup--p-em">Sunday, September 25, 2016 | Westin St. Francis, San Francisco</em></p>
+                        <p id="1807" className="graf--p graf-after--p">It is with great excitement that we announce “Satoshi’s Vision: Bitcoin Development &amp; Scaling Conference.” This single-day event will bring together like-minded developers, researchers and industry leaders committed to the vision of Bitcoin as a peer-to-peer electronic cash system for the world’s seven billion people.</p>
 
-                        <h4 id="9440" class="graf--h4 graf-after--p">Venue</h4>
-                        <p id="0ff4" class="graf--p graf-after--h4">The event will be held at the <a class="markup--anchor markup--p-anchor" href="http://westinstfrancis.com/" target="_blank" rel="nofollow" data-href="http://westinstfrancis.com/">St. Francis Hotel</a>, overlooking Union Square in the heart of San Francisco.</p>
+                        <h4 id="9440" className="graf--h4 graf-after--p">Venue</h4>
+                        <p id="0ff4" className="graf--p graf-after--h4">The event will be held at the <a className="markup--anchor markup--p-anchor" href="http://westinstfrancis.com/" target="_blank" rel="nofollow" data-href="http://westinstfrancis.com/">St. Francis Hotel</a>, overlooking Union Square in the heart of San Francisco.</p>
 
 
-                        <figure id="7335" class="graf--figure graf-after--p">
-                        <div class="aspectRatioPlaceholder is-locked"></div>
+                        <figure id="7335" className="graf--figure graf-after--p">
+                        <div className="aspectRatioPlaceholder is-locked"></div>
                         </figure>
-                        <h4 id="0750" class="graf--h4 graf-after--figure">Agenda</h4>
-                        <p id="6dc6" class="graf--p graf-after--h4">The morning session will explore the scaling solutions developed over the past year, ready and waiting to meet an order-of-magnitude increase in transactional demand. The afternoon session will focus on longer-term scaling initiatives to on-board Bitcoin’s first billion users.</p>
-                        <p id="2645" class="graf--p graf-after--p">The agenda is designed to maximize discussion among conference attendees. Talks will be short (two 20-min talks and approximately eight 10-min “mini talks”) and each will be followed by a Q&amp;A period. The panel sessions will be interactive with the audience, and the breakout sessions will give all attendees a chance to further develop ideas related to the topics introduced in the talks and panel sessions.</p>
-                        <p id="c6ea" class="graf--p graf-after--p">The day will conclude with a dinner reception at a <a class="markup--anchor markup--p-anchor" href="http://www.bartartine.com/" target="_blank" rel="nofollow" data-href="http://www.bartartine.com/">popular eatery</a>.</p>
+                        <h4 id="0750" className="graf--h4 graf-after--figure">Agenda</h4>
+                        <p id="6dc6" className="graf--p graf-after--h4">The morning session will explore the scaling solutions developed over the past year, ready and waiting to meet an order-of-magnitude increase in transactional demand. The afternoon session will focus on longer-term scaling initiatives to on-board Bitcoin’s first billion users.</p>
+                        <p id="2645" className="graf--p graf-after--p">The agenda is designed to maximize discussion among conference attendees. Talks will be short (two 20-min talks and approximately eight 10-min “mini talks”) and each will be followed by a Q&amp;A period. The panel sessions will be interactive with the audience, and the breakout sessions will give all attendees a chance to further develop ideas related to the topics introduced in the talks and panel sessions.</p>
+                        <p id="c6ea" className="graf--p graf-after--p">The day will conclude with a dinner reception at a <a className="markup--anchor markup--p-anchor" href="http://www.bartartine.com/" target="_blank" rel="nofollow" data-href="http://www.bartartine.com/">popular eatery</a>.</p>
 
-                        <figure id="a6fc" class="graf--figure graf-after--p">
-                        <div class="aspectRatioPlaceholder is-locked">
-                        <div class="aspectRatioPlaceholder-fill"></div>
-                        <div class="progressiveMedia js-progressiveMedia graf-image is-canvasLoaded is-imageLoaded" data-image-id="1*zHL1XksSG4GnOrSXqvmImQ.png" data-width="886" data-height="1728" data-action="zoom" data-action-value="1*zHL1XksSG4GnOrSXqvmImQ.png" data-scroll="native"><canvas class="progressiveMedia-canvas js-progressiveMedia-canvas" width="38" height="75"></canvas><img class="progressiveMedia-image js-progressiveMedia-image" src="https://cdn-images-1.medium.com/max/800/1*zHL1XksSG4GnOrSXqvmImQ.png" data-src="https://cdn-images-1.medium.com/max/800/1*zHL1XksSG4GnOrSXqvmImQ.png" /></div>
+                        <figure id="a6fc" className="graf--figure graf-after--p">
+                        <div className="aspectRatioPlaceholder is-locked">
+                        <div className="aspectRatioPlaceholder-fill"></div>
+                        <div className="progressiveMedia js-progressiveMedia graf-image is-canvasLoaded is-imageLoaded" data-image-id="1*zHL1XksSG4GnOrSXqvmImQ.png" data-width="886" data-height="1728" data-action="zoom" data-action-value="1*zHL1XksSG4GnOrSXqvmImQ.png" data-scroll="native"><canvas className="progressiveMedia-canvas js-progressiveMedia-canvas" width="38" height="75"></canvas><img className="progressiveMedia-image js-progressiveMedia-image" src="https://cdn-images-1.medium.com/max/800/1*zHL1XksSG4GnOrSXqvmImQ.png" data-src="https://cdn-images-1.medium.com/max/800/1*zHL1XksSG4GnOrSXqvmImQ.png" /></div>
                         </div>
                         </figure>
-                        <h4 id="538e" class="graf--h4 graf-after--figure">Tickets</h4>
-                        <p id="6f0e" class="graf--p graf-after--h4">Although the conference is intended to be a small and intimate event, a very limited number of tickets can be purchased via <a class="markup--anchor markup--p-anchor" href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878" target="_blank" rel="nofollow" data-href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878">this webform</a>.</p>
+                        <h4 id="538e" className="graf--h4 graf-after--figure">Tickets</h4>
+                        <p id="6f0e" className="graf--p graf-after--h4">Although the conference is intended to be a small and intimate event, a very limited number of tickets can be purchased via <a className="markup--anchor markup--p-anchor" href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878" target="_blank" rel="nofollow" data-href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878">this webform</a>.</p>
 
-                        <h4 id="17e3" class="graf--h4 graf-after--p">Acknowledgement</h4>
-                        <p id="5030" class="graf--p graf-after--h4 graf--last">We gratefully acknowledge the extremely generous donations made anonymously to the <a class="markup--anchor markup--p-anchor" href="https://www.bitcoinunlimited.info/" target="_blank" rel="nofollow" data-href="https://www.bitcoinunlimited.info">Bitcoin Unlimited Community Organization</a> that make this event possible.</p>
+                        <h4 id="17e3" className="graf--h4 graf-after--p">Acknowledgement</h4>
+                        <p id="5030" className="graf--p graf-after--h4 graf--last">We gratefully acknowledge the extremely generous donations made anonymously to the <a className="markup--anchor markup--p-anchor" href="https://www.bitcoinunlimited.info/" target="_blank" rel="nofollow" data-href="https://www.bitcoinunlimited.info">Bitcoin Unlimited Community Organization</a> that make this event possible.</p>
                     </div>
                 </div>
                 <Footer />

--- a/src/public/views/pages/conferences.jsx
+++ b/src/public/views/pages/conferences.jsx
@@ -16,33 +16,20 @@ export default React.createClass({
                 <Title title="Satoshi's Vision" />
                 <div className='section'>
                     <div className='container'>
-                        <h1 id="5eed" className="graf--h3 graf--leading graf--title">Satoshi’s Vision: Bitcoin Development &amp; Scaling Conference</h1>
-                        <p id="7afc" className="graf--p graf-after--h3"><em className="markup--em markup--p-em">Sunday, September 25, 2016 | Westin St. Francis, San Francisco</em></p>
-                        <p id="1807" className="graf--p graf-after--p">It is with great excitement that we announce “Satoshi’s Vision: Bitcoin Development &amp; Scaling Conference.” This single-day event will bring together like-minded developers, researchers and industry leaders committed to the vision of Bitcoin as a peer-to-peer electronic cash system for the world’s seven billion people.</p>
-
-                        <h4 id="9440" className="graf--h4 graf-after--p">Venue</h4>
-                        <p id="0ff4" className="graf--p graf-after--h4">The event will be held at the <a className="markup--anchor markup--p-anchor" href="http://westinstfrancis.com/" target="_blank" rel="nofollow" data-href="http://westinstfrancis.com/">St. Francis Hotel</a>, overlooking Union Square in the heart of San Francisco.</p>
-
-
-                        <figure id="7335" className="graf--figure graf-after--p">
-                        <div className="aspectRatioPlaceholder is-locked"></div>
-                        </figure>
-                        <h4 id="0750" className="graf--h4 graf-after--figure">Agenda</h4>
-                        <p id="6dc6" className="graf--p graf-after--h4">The morning session will explore the scaling solutions developed over the past year, ready and waiting to meet an order-of-magnitude increase in transactional demand. The afternoon session will focus on longer-term scaling initiatives to on-board Bitcoin’s first billion users.</p>
-                        <p id="2645" className="graf--p graf-after--p">The agenda is designed to maximize discussion among conference attendees. Talks will be short (two 20-min talks and approximately eight 10-min “mini talks”) and each will be followed by a Q&amp;A period. The panel sessions will be interactive with the audience, and the breakout sessions will give all attendees a chance to further develop ideas related to the topics introduced in the talks and panel sessions.</p>
-                        <p id="c6ea" className="graf--p graf-after--p">The day will conclude with a dinner reception at a <a className="markup--anchor markup--p-anchor" href="http://www.bartartine.com/" target="_blank" rel="nofollow" data-href="http://www.bartartine.com/">popular eatery</a>.</p>
-
-                        <figure id="a6fc" className="graf--figure graf-after--p">
-                        <div className="aspectRatioPlaceholder is-locked">
-                        <div className="aspectRatioPlaceholder-fill"></div>
-                        <div className="progressiveMedia js-progressiveMedia graf-image is-canvasLoaded is-imageLoaded" data-image-id="1*zHL1XksSG4GnOrSXqvmImQ.png" data-width="886" data-height="1728" data-action="zoom" data-action-value="1*zHL1XksSG4GnOrSXqvmImQ.png" data-scroll="native"><canvas className="progressiveMedia-canvas js-progressiveMedia-canvas" width="38" height="75"></canvas><img className="progressiveMedia-image js-progressiveMedia-image" src="https://cdn-images-1.medium.com/max/800/1*zHL1XksSG4GnOrSXqvmImQ.png" data-src="https://cdn-images-1.medium.com/max/800/1*zHL1XksSG4GnOrSXqvmImQ.png" /></div>
-                        </div>
-                        </figure>
-                        <h4 id="538e" className="graf--h4 graf-after--figure">Tickets</h4>
-                        <p id="6f0e" className="graf--p graf-after--h4">Although the conference is intended to be a small and intimate event, a very limited number of tickets can be purchased via <a className="markup--anchor markup--p-anchor" href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878" target="_blank" rel="nofollow" data-href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878">this webform</a>.</p>
-
-                        <h4 id="17e3" className="graf--h4 graf-after--p">Acknowledgement</h4>
-                        <p id="5030" className="graf--p graf-after--h4 graf--last">We gratefully acknowledge the extremely generous donations made anonymously to the <a className="markup--anchor markup--p-anchor" href="https://www.bitcoinunlimited.info/" target="_blank" rel="nofollow" data-href="https://www.bitcoinunlimited.info">Bitcoin Unlimited Community Organization</a> that make this event possible.</p>
+                        <h1>Satoshi’s Vision: Bitcoin Development &amp; Scaling Conference</h1>
+                        <p><em>Sunday, September 25, 2016 | Westin St. Francis, San Francisco</em></p>
+                        <p>It is with great excitement that we announce “Satoshi’s Vision: Bitcoin Development & Scaling Conference.” This single-day event will bring together like-minded developers, researchers and industry leaders committed to the vision of Bitcoin as a peer-to-peer electronic cash system for the world’s seven billion people.</p>
+                        <h4>Venue</h4>
+                        <p>The event will be held at the <a href='http://westinstfrancis.com/' target='_blank' rel='nofollow'>St. Francis Hotel</a>, overlooking Union Square in the heart of San Francisco.</p>
+                        <h4>Agenda</h4>
+                        <p>The morning session will explore the scaling solutions developed over the past year, ready and waiting to meet an order-of-magnitude increase in transactional demand. The afternoon session will focus on longer-term scaling initiatives to on-board Bitcoin’s first billion users.</p>
+                        <p>The agenda is designed to maximize discussion among conference attendees. Talks will be short (two 20-min talks and approximately eight 10-min “mini talks”) and each will be followed by a Q&amp;A period. The panel sessions will be interactive with the audience, and the breakout sessions will give all attendees a chance to further develop ideas related to the topics introduced in the talks and panel sessions.</p>
+                        <p>The day will conclude with a dinner reception at a <a href='http://www.bartartine.com/' target='_blank' rel='nofollow'>popular eatery</a>.</p>
+                        <img src='https://cdn-images-1.medium.com/max/800/1*zHL1XksSG4GnOrSXqvmImQ.png' />
+                        <h4>Tickets</h4>
+                        <p>Although the conference is intended to be a small and intimate event, a very limited number of tickets can be purchased via <a href='https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878' target='_blank' rel='nofollow'>this webform</a>.</p>
+                        <h4>Acknowledgement</h4>
+                        <p>We gratefully acknowledge the extremely generous donations made anonymously to the <a href='https://www.bitcoinunlimited.info/' target='_blank' rel='nofollow'>Bitcoin Unlimited Community Organization</a> that make this event possible.</p>
                     </div>
                 </div>
                 <Footer />

--- a/src/public/views/pages/conferences.jsx
+++ b/src/public/views/pages/conferences.jsx
@@ -42,7 +42,7 @@ export default React.createClass({
                         <p id="6f0e" class="graf--p graf-after--h4">Although the conference is intended to be a small and intimate event, a very limited number of tickets can be purchased via <a class="markup--anchor markup--p-anchor" href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878" target="_blank" rel="nofollow" data-href="https://docs.google.com/forms/d/e/1FAIpQLSfy1C4_RLs_T6CxRGXA92N7jXOamucFKjXrCLNb6YXt9iBGaA/viewform?entry.1898126628=1&amp;entry.597557985&amp;entry.195460802&amp;entry.967622631=No&amp;entry.1600438880=No&amp;entry.389789878">this webform</a>.</p>
 
                         <h4 id="17e3" class="graf--h4 graf-after--p">Acknowledgement</h4>
-                        <p id="5030" class="graf--p graf-after--h4 graf--last">We gratefully acknowledge the extremely generous donations made anonymously to the <a class="markup--anchor markup--p-anchor" href="http://bitcoinunlimited.info/" target="_blank" rel="nofollow" data-href="http://bitcoinunlimited.info">Bitcoin Unlimited Community Organization</a> that make this event possible.</p>
+                        <p id="5030" class="graf--p graf-after--h4 graf--last">We gratefully acknowledge the extremely generous donations made anonymously to the <a class="markup--anchor markup--p-anchor" href="https://www.bitcoinunlimited.info/" target="_blank" rel="nofollow" data-href="https://www.bitcoinunlimited.info">Bitcoin Unlimited Community Organization</a> that make this event possible.</p>
                     </div>
                 </div>
                 <Footer />

--- a/src/public/views/pages/conferences.jsx
+++ b/src/public/views/pages/conferences.jsx
@@ -11,8 +11,8 @@ export default React.createClass({
 
     render: function() {
         return (
-            <div id='conference'>
-                <Header active='conference' />
+            <div id='conferences'>
+                <Header active='conferences' />
                 <Title title="Satoshi's Vision" />
                 <div className='section'>
                     <div className='container'>
@@ -22,7 +22,7 @@ export default React.createClass({
 
                         <h4 id="9440" class="graf--h4 graf-after--p">Venue</h4>
                         <p id="0ff4" class="graf--p graf-after--h4">The event will be held at the <a class="markup--anchor markup--p-anchor" href="http://westinstfrancis.com/" target="_blank" rel="nofollow" data-href="http://westinstfrancis.com/">St. Francis Hotel</a>, overlooking Union Square in the heart of San Francisco.</p>
-                        
+
 
                         <figure id="7335" class="graf--figure graf-after--p">
                         <div class="aspectRatioPlaceholder is-locked"></div>
@@ -31,7 +31,7 @@ export default React.createClass({
                         <p id="6dc6" class="graf--p graf-after--h4">The morning session will explore the scaling solutions developed over the past year, ready and waiting to meet an order-of-magnitude increase in transactional demand. The afternoon session will focus on longer-term scaling initiatives to on-board Bitcoin’s first billion users.</p>
                         <p id="2645" class="graf--p graf-after--p">The agenda is designed to maximize discussion among conference attendees. Talks will be short (two 20-min talks and approximately eight 10-min “mini talks”) and each will be followed by a Q&amp;A period. The panel sessions will be interactive with the audience, and the breakout sessions will give all attendees a chance to further develop ideas related to the topics introduced in the talks and panel sessions.</p>
                         <p id="c6ea" class="graf--p graf-after--p">The day will conclude with a dinner reception at a <a class="markup--anchor markup--p-anchor" href="http://www.bartartine.com/" target="_blank" rel="nofollow" data-href="http://www.bartartine.com/">popular eatery</a>.</p>
-                        
+
                         <figure id="a6fc" class="graf--figure graf-after--p">
                         <div class="aspectRatioPlaceholder is-locked">
                         <div class="aspectRatioPlaceholder-fill"></div>


### PR DESCRIPTION
- Nit: Changes the page's link from `conference` to `conferences`
- Nit: Changes the BU link to use `https` and `www`
- React fix: Uses `className` property instead of `class`
- Cleanup: Removes the leftover artifacts from Medium's markup
